### PR TITLE
10.0.1.36

### DIFF
--- a/ActPowerCLI.psd1
+++ b/ActPowerCLI.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ActPowerCLI.psm1'
 
 # Version number of this module.
-ModuleVersion = '10.0.1.35'
+ModuleVersion = '10.0.1.36'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -27,7 +27,7 @@ Author = 'Anthony Vandewerdt'
 CompanyName = 'Actifio'
 
 # Copyright statement for this module
-Copyright = '(c) 2020 Actifio, Inc. All rights reserved'
+Copyright = '(c) 2021 Actifio, Inc. All rights reserved'
 
 ##################################################################################################################
 # Description of the functionality provided by this module
@@ -111,6 +111,9 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+        ## [10.0.1.36] 2021-11-16
+        The check for env:acthost was swapped with env:actsessionid at some point, resulting in a double check for env:actsessionid 
+
         ## [10.0.1.35] 2021-11-08
         Finally removed all PS4 content.  The DLL is now finally gone.  This module will only support PS5 going forward
         Added configurable timeout using -timeout with connect-act

--- a/ActPowerCLI.psm1
+++ b/ActPowerCLI.psm1
@@ -515,7 +515,7 @@ function Get-SARGReport([string]$reportname,[string]$sargparms,[switch][alias("h
 
 
     # make sure we have something to connect to
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act"  
         return;
@@ -684,7 +684,7 @@ function Get-SARGReport([string]$reportname,[string]$sargparms,[switch][alias("h
 # we dont want to precreate all the SARG functions, but reportlist is a good one to help the client understand if SARG commands dont work.
 function reportlist ()
 {
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act.  Report commands are only loaded after you login to an Appliance."  
         return;
@@ -708,7 +708,7 @@ function New-SARGFuncs()
 
 
     # make sure we have something to connect to
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act"  
         return;
@@ -844,7 +844,7 @@ Function udsinfo([string]$subcommand, [switch][alias("h")]$help)
     #>
 
     # make sure we have something to connect to
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act"  
         return;
@@ -1000,7 +1000,7 @@ Function udstask ([string]$subcommand, [switch][alias("h")]$help)
     # this function will imitate udstask so that users don't need to remember each
     # individual function.
     # make sure we have something to connect to
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act"  
         return;
@@ -1128,7 +1128,7 @@ Function usvcinfo([string]$subcommand)
    
     # no help is available for this command
     # make sure we have something to connect to
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act"  
         return;
@@ -1188,7 +1188,7 @@ Function usvctask([string]$subcommand)
 
     # this command will allow users to run specific usvctask commands.
     # make sure we have something to connect to
-    if ( (!($env:ACTSESSIONID)) -or (!($env:ACTSESSIONID)) ) 
+    if ( (!($env:ACTSESSIONID)) -or (!($env:acthost)) ) 
     { 
         Get-ActErrorMessage -messagetoprint "Not logged in or session expired. Please login using Connect-Act"  
         return;

--- a/ActPowerCLI.psm1
+++ b/ActPowerCLI.psm1
@@ -1,5 +1,5 @@
 # # Version number of this module.
-# ModuleVersion = '10.0.1.35'
+# ModuleVersion = '10.0.1.36'
 function psfivecerthandler
 {
     if (-not ([System.Management.Automation.PSTypeName]'ServerCertificateValidationCallback').Type)

--- a/Install-ActPowerCLI.ps1
+++ b/Install-ActPowerCLI.ps1
@@ -222,7 +222,7 @@ function silentinstall
   exit
 }
 
-if ($args[0] -eq "-silentinstall0")
+if (($args[0] -eq "-silentinstall0") -or ($args[0] -eq "-s0"))
 {
   silentinstall0
 }

--- a/Install-ActPowerCLI.ps1
+++ b/Install-ActPowerCLI.ps1
@@ -227,12 +227,12 @@ if ($args[0] -eq "-silentinstall0")
   silentinstall0
 }
 
-if ($args[0] -eq "-silentinstall")
+if (($args[0] -eq "-silentinstall") -or ($args[0] -eq "-s"))
 {
   silentinstall
 }
 
-if ($args[0] -eq "-silentuninstall")
+if (($args[0] -eq "-silentuninstall")  -or ($args[0] -eq "-u"))
 {
   [Array]$ActInstall = GetActPowerCLIInstall
   foreach ($Location in ([Array]$ActInstall = GetActPowerCLIInstall).ModuleBase)

--- a/README.md
+++ b/README.md
@@ -112,10 +112,9 @@ Common upgrade issues are solved by:
 
 You can run a silent install by adding -silentinstall or -silentinstall0
 
-* -silentinstall0 or -s0 will the module in 'slot 0'
-* -silentinstall will the module in 'slot 1'
-* -s will install the module either in the same location where it is currenly installed, or into the '1' location.
-* -silentuninstall or -u will silently uninstall the module.   You may need to exit the session to remove the module from memory
+* **-silentinstall0** or **-s0** will install the module in 'slot 0'
+* **-silentinstall** or **-s** will install the module in 'slot 1' or in the same location where it is currenly installed
+* **-silentuninstall** or **-u** will silently uninstall the module.   You may need to exit the session to remove the module from memory
 
 By slot we mean the output of **$env:PSModulePath** where 0 is the first module in the list, 1 is the second module and so on.
 Note that if the module is already installed, then if you specify **-silentinstall** or **-s** it will reinstall in the same folder.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ You can run a silent install by adding -silentinstall or -silentinstall0
 By slot we mean the output of **$env:PSModulePath** where 0 is the first module in the list, 1 is the second module and so on.
 Note that if the module is already installed, then if you specify **-silentinstall** or **-s** it will reinstall in the same folder.
 
+Usage example:
+```
+PS /Users/avw> ./ActPowerCLI/Install-ActPowerCLI.ps1 -s0
+Detected PowerShell version:    7
+Downloaded ActPowerCLI version: 10.0.1.36
+Installed ActPowerCLI version:  10.0.1.36 in  /Users/avw/.local/share/powershell/Modules/ActPowerCLI/
+PS /Users/avw>
+```
+
 
 #### GITHUB Install fails with Access to the path 'ActPowerCLI.dll' is denied.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Common upgrade issues are solved by:
 * Unblocking the downloaded zip file.
 * Running the PowerShell session as Administrator, depending on where current installs are and where you want to install to.
 
-### Silent install
+#### Silent install using downloaded github installer
 
 You can run a silent install by adding -silentinstall or -silentinstall0
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,13 @@ Common upgrade issues are solved by:
 
 You can run a silent install by adding -silentinstall or -silentinstall0
 
-* -silentinstall0 will the module in 'slot 0'
+* -silentinstall0 or -s0 will the module in 'slot 0'
 * -silentinstall will the module in 'slot 1'
+* -s will install the module either in the same location where it is currenly installed, or into the '1' location.
+* -silentuninstall or -u will silently uninstall the module.   You may need to exit the session to remove the module from memory
 
 By slot we mean the output of **$env:PSModulePath** where 0 is the first module in the list, 1 is the second module and so on.
-Note that if the module is already installed, then if you specify **-silentinstall** it will reinstall in the same folder.
+Note that if the module is already installed, then if you specify **-silentinstall** or **-s** it will reinstall in the same folder.
 
 
 #### GITHUB Install fails with Access to the path 'ActPowerCLI.dll' is denied.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Common upgrade issues are solved by:
 * Unblocking the downloaded zip file.
 * Running the PowerShell session as Administrator, depending on where current installs are and where you want to install to.
 
-#### Silent install
+### Silent install
 
 You can run a silent install by adding -silentinstall or -silentinstall0
 


### PR DESCRIPTION
## [10.0.1.36] 2021-11-16
 The check for env:acthost was swapped with env:actsessionid at some point, resulting in a double check for env:actsessionid 